### PR TITLE
Consolidated checks for build success/failure, warnings, added [WARNING]

### DIFF
--- a/mvn
+++ b/mvn
@@ -4,15 +4,12 @@
 alias maven="command mvn"
 color_maven() {
   maven $* | sed -e 's/Tests run: \([^,]*\), Failures: \([^,]*\), Errors: \([^,]*\), Skipped: \([^,]*\)/[1;32mTests run: \1[0m, Failures: [1;31m\2[0m, Errors: [1;33m\3[0m, Skipped: [1;34m\4[0m/g' \
-    -e 's/\(\[WARN\].*\)/[1;33m\1[0m/g' \
-    -e 's/\(WARN.*\)/[0;33m\1[0m/g' \
+    -e 's/\(\[\{0,1\}WARN\(ING\)\{0,1\}\]\{0,1\}.*\)/[1;33m\1[0m/g' \
     -e 's/\(\[INFO\].*\)/[1;32m\1[0m/g' \
     -e 's/\(\[ERROR\].*\)/[1;31m\1[0m/g' \
-    -e 's/\(BUILD FAILURE.*\)/[1;31m\1[0m/g' \
-    -e 's/\(FAILURE!.*\)/[1;31m\1[0m/g' \
-    -e 's/\(BUILD SUCCESS.*\)/[1;37m\1[0m/g' \
-    -e 's/\(SUCCESS.*\)/[1;37m\1[0m/g' 
-    
+    -e 's/\(\(BUILD \)\{0,1\}FAILURE.*\)/[1;31m\1[0m/g' \
+    -e 's/\(\(BUILD \)\{0,1\}SUCCESS.*\)/[1;37m\1[0m/g'
+
     return $PIPESTATUS
 }
 


### PR DESCRIPTION
Added the missing `[WARNING]` colorization, and consolidated the other checks while at it.

`[WARNING]` was actually partially covered by the `WARN` check, but the first `[` wasn't colorized.
